### PR TITLE
Allow caller to provide an s3 client

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 var AWS = require('aws-sdk');
-var s3 = new AWS.S3();
 var queue = require('queue-async');
 
 module.exports = cleanup;
 module.exports.listAll = listAll;
-module.exports.s3 = s3;
 
 /**
  * Cleanup stale S3 multipart uploads by aborting stale MPUs.
@@ -12,11 +10,13 @@ module.exports.s3 = s3;
  * @param {String} options.bucket S3 bucket to cleanup
  * @param {Date} options.before Oldest date of MPUs to leave untouched. Defaults to the current time - 24 hours
  * @param {Function} options.logger Optional function to call after each abort operation for logging
+ * @param {Object} options.s3 Optional s3 client to use
  * @param {Function} callback Callback function
  */
 function cleanup(options, callback) {
     options.before = options.before || new Date(+new Date() - 864e5);
     options.logger = options.logger || function() {};
+    var s3 = options.s3 || new AWS.S3();
     listAll(options, function(err, uploads) {
         if (err) return callback(err);
         var q = queue(4);
@@ -47,9 +47,11 @@ function cleanup(options, callback) {
  * List all MPUs for a bucket.
  * @param {Object} options
  * @param {String} options.bucket S3 bucket to list
+ * @param {Object} options.s3 Optional s3 client to use
  * @param {Function} callback Callback function
  */
 function listAll(options, callback) {
+    var s3 = options.s3 || new AWS.S3();
     var uploads = [];
     function ls(markers) {
         var params ={ Bucket: options.bucket };
@@ -69,4 +71,3 @@ function listAll(options, callback) {
     }
     ls();
 }
-

--- a/test.js
+++ b/test.js
@@ -1,61 +1,10 @@
 var tape = require('tape');
 var s3mpuCleanup = require('./index');
 
-tape('listAll', function(assert) {
-    s3mpuCleanup.listAll({ bucket: 'test-bucket' }, function(err, data) {
-        assert.ifError(err);
-        assert.equal(data.length, 3, 'lists for all items using marker');
-        assert.deepEqual(data.map(function(o) { return o.UploadId; }), [
-            'id.1',
-            'id.2',
-            'id.3'
-        ], 'returns upload items');
-        assert.end();
-    });
-});
-
-tape('cleanup (defaults)', function(assert) {
-    s3mpuCleanup({bucket:'test-bucket'}, function(err, aborted) {
-        assert.ifError(err);
-        assert.deepEqual(aborted, [
-            's3://test-bucket/a.json@id.1'
-        ], 'aborts expired a.json@id.1');
-        assert.end();
-    });
-});
-
-tape('cleanup (logger)', function(assert) {
-    var logged = [];
-    s3mpuCleanup({
-        bucket:'test-bucket',
-        logger: function(entry) {
-            logged.push(entry);
-        }
-    }, function(err, aborted) {
-        assert.ifError(err);
-        assert.deepEqual(aborted, [
-            's3://test-bucket/a.json@id.1'
-        ], 'aborts expired a.json@id.1');
-        assert.deepEqual(logged, [
-            's3://test-bucket/a.json@id.1'
-        ], 'calls logger function');
-        assert.end();
-    });
-});
-
-tape('cleanup (before=10min ago)', function(assert) {
-    s3mpuCleanup({bucket:'test-bucket', before: new Date(+new Date - 60e3)}, function(err, aborted) {
-        assert.ifError(err);
-        assert.deepEqual(aborted, [
-            's3://test-bucket/a.json@id.1',
-            's3://test-bucket/c.json@id.3'
-        ], 'aborts expired a.json@id.1, c.json@id.3');
-        assert.end();
-    });
-});
+var s3 = {};
 
 // Mock abortMultipartUpload behavior.
-s3mpuCleanup.s3.abortMultipartUpload = function(options, callback) {
+s3.abortMultipartUpload = function(options, callback) {
     if (!options.Bucket || !options.UploadId || !options.Key) {
         throw new Error('Bucket, UploadId, Key params are required');
     }
@@ -63,7 +12,7 @@ s3mpuCleanup.s3.abortMultipartUpload = function(options, callback) {
 };
 
 // Mock listMultipartUploads behavior.
-s3mpuCleanup.s3.listMultipartUploads = function(options, callback) {
+s3.listMultipartUploads = function(options, callback) {
     if (options.Bucket === 'test-bucket' && !options.KeyMarker) {
         return callback(null, {
             "Bucket": "test-bucket",
@@ -137,4 +86,56 @@ s3mpuCleanup.s3.listMultipartUploads = function(options, callback) {
     }
 };
 
+tape('listAll', function(assert) {
+    s3mpuCleanup.listAll({ s3: s3, bucket: 'test-bucket' }, function(err, data) {
+        assert.ifError(err);
+        assert.equal(data.length, 3, 'lists for all items using marker');
+        assert.deepEqual(data.map(function(o) { return o.UploadId; }), [
+            'id.1',
+            'id.2',
+            'id.3'
+        ], 'returns upload items');
+        assert.end();
+    });
+});
 
+tape('cleanup (defaults)', function(assert) {
+    s3mpuCleanup({s3: s3, bucket:'test-bucket'}, function(err, aborted) {
+        assert.ifError(err);
+        assert.deepEqual(aborted, [
+            's3://test-bucket/a.json@id.1'
+        ], 'aborts expired a.json@id.1');
+        assert.end();
+    });
+});
+
+tape('cleanup (logger)', function(assert) {
+    var logged = [];
+    s3mpuCleanup({
+        s3: s3,
+        bucket:'test-bucket',
+        logger: function(entry) {
+            logged.push(entry);
+        }
+    }, function(err, aborted) {
+        assert.ifError(err);
+        assert.deepEqual(aborted, [
+            's3://test-bucket/a.json@id.1'
+        ], 'aborts expired a.json@id.1');
+        assert.deepEqual(logged, [
+            's3://test-bucket/a.json@id.1'
+        ], 'calls logger function');
+        assert.end();
+    });
+});
+
+tape('cleanup (before=10min ago)', function(assert) {
+    s3mpuCleanup({s3: s3, bucket:'test-bucket', before: new Date(+new Date - 60e3)}, function(err, aborted) {
+        assert.ifError(err);
+        assert.deepEqual(aborted, [
+            's3://test-bucket/a.json@id.1',
+            's3://test-bucket/c.json@id.3'
+        ], 'aborts expired a.json@id.1, c.json@id.3');
+        assert.end();
+    });
+});


### PR DESCRIPTION
Instead of defining the s3 client at the module level where only one can exist per process. This would let me run a process that uses different s3 clients for buckets in different regions (looking at you `eu-central-1`).

cc @yhahn 
